### PR TITLE
Adaptive threshold based on automated ammo count

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,9 @@
 ---------------------------------------------------------------------------------------------------
+Version: 1.1.7
+Date: 2021-06-21
+  Compatibility:
+    - Added compatibility to Space Exploration's Meteor defence and other mods (no longer displays alert when ammo is dynamically loaded) (by snouz)
+---------------------------------------------------------------------------------------------------
 Version: 1.1.6
 Date: 2021-04-22
   Bugfixes:

--- a/control.lua
+++ b/control.lua
@@ -166,6 +166,11 @@ local function generate_alerts()
 					if inventory and get_ammo_flag[mode] then
 						if entity.type == "ammo-turret" then
 							ammo_flag = get_ammo_flag[mode](inventory, player_threshold)
+							if entity.prototype.automated_ammo_count then
+								if entity.prototype.automated_ammo_count < player_threshold then
+									ammo_flag = get_ammo_flag[mode](inventory, entity.prototype.automated_ammo_count)
+								end
+							end
 						elseif entity.type == "car" then
 							ammo_flag = get_ammo_flag[mode](inventory, player_threshold, entity.selected_gun_index)
 						end

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
     "name": "Gun_Turret_Alerts",
-    "version": "1.1.6",
+    "version": "1.1.7",
     "title": "Ammo Alerts",
     "author": "Wyrrrd",
     "factorio_version": "1.1",

--- a/locale/de/config.cfg
+++ b/locale/de/config.cfg
@@ -18,3 +18,7 @@ autofilter_mode-selected=Auswahl
 [gun-turret-alerts]
 message-empty=__1__ hat keine Munition
 message-low=__1__ hat wenig Munition
+
+[virtual-signal-name]
+ammo-icon-red=Hat keine Munition
+ammo-icon-yellow=Hat wenig Munition

--- a/locale/en/config.cfg
+++ b/locale/en/config.cfg
@@ -17,4 +17,8 @@ autofilter_mode-selected=Selected
 
 [gun-turret-alerts]
 message-empty=__1__ out of ammo
-message-low=__1__ ammo low
+message-low=__1__ low ammo
+
+[virtual-signal-name]
+ammo-icon-red=Out of ammo signal
+ammo-icon-yellow=Low ammo signal


### PR DESCRIPTION
-Threshold for alert comes is never higher than then number of ammo loaded by an inserter.
-This fixes annoying alerts in Space Exploration's meteor defence, where the default ammo loaded is 4, and fixes the problem for any other mod.

Tested and working.